### PR TITLE
indication can be a bit pattern

### DIFF
--- a/draft-thoji-scone-trone-protocol.md
+++ b/draft-thoji-scone-trone-protocol.md
@@ -313,58 +313,36 @@ transport parameters, and frame types registries established in {{Sections 22.2,
 # TRONE Indication {#trone-indication}
 
 QUIC endpoints can signal potential support for TRONE before the completion of
-the QUIC handshake by attaching a TRONE indication packet after the last QUIC
-long header packet in the first UDP datagram. The TRONE indication provides an
-opportunistic signal to network elements that the client might support TRONE.
-Network elements can use this as an early hint, but must await confirmation of
-TRONE support by observing a full TRONE packet after the handshake completes.
+the QUIC handshake by sending a QUIC long header packet as the first UDP
+datagram with its last 16 bytes set to the TRONE Indication Pattern.
 
-When sending QUIC short header packets in the first flight, endpoints SHOULD
-send them separately from the first datagram carrying the TRONE indication
-packet, to avoid receivers incapable of decoding TRONE packets from dropping
-the short header packet.
+The TRONE Indication Pattern is "givemesomescone!" encoded in US-ASCII.
 
-## TRONE Indication Packet
+The TRONE indication provides an opportunistic signal to network elements that
+the client might support TRONE. Network elements can use this as an early hint,
+but must await confirmation of TRONE support by observing a full TRONE packet
+after the handshake completes.
 
-A TRONE indication packet has a format with fully reversed field order compared
-to TRONE packets to facilitate detection by parsing from the end of the packet.
-
-{{fig-trone-indication-packet}} shows the format of the TRONE indication packet:
-
-~~~ artwork
-TRONE Indication Packet {
-  Source Connection ID (0..2040),
-  Source Connection ID Length (8),
-  Destination Connection ID (0..2040),
-  Destination Connection ID Length (8),
-  Version (32) = 0xTRONE1 or 0xTRONE2,
-  Rate Signal (6) = 0x3F,
-  Reserved (1),
-  Header Form (1) = 1
-}
-~~~
-{: #fig-trone-indication-packet title="TRONE Indication Packet Format"}
-
-A TRONE indication packet is attached directly after a QUIC Initial packet in
-the first UDP datagram. The Rate Signal field MUST be set to 0x3F (63) when
-sent as a TRONE indication packet.
 
 ## Sending TRONE Indication
 
-A QUIC endpoint that supports TRONE MAY attach a TRONE indication packet after
-a QUIC Initial packet in the first UDP datagram. This is an opportunistic
-signal that is not guaranteed to be processed by the receiver, as the receiver
-has not yet confirmed its willingness to receive TRONE packets.
+When indicating support for TRONE, a QUIC endpoint sets the last 16 bytes of the
+first UDP datagram it sends to the TRONE Indication Pattern. This is an
+opportunistic signal that is not guaranteed to be processed by the receiver, as
+the receiver has not yet confirmed its willingness to send TRONE packets.
 
-When attaching a TRONE indication, the endpoint SHOULD:
-* Place it immediately after the QUIC Initial packet in the datagram
-* Construct the packet with reversed field order as shown in
-  {{fig-trone-indication-packet}}
-* Set the Source Connection ID and Destination Connection ID fields to match
-  those of the QUIC Initial packet
-* Set the Version field to either 0xTRONE1 or 0xTRONE2
-* Set the Header Form bit to 1 (maintaining QUIC invariants)
-* Set the Rate Signal field to 0x3F (63)
+In the case of QUIC v1, endpoints can simply append the TRONE Indication Pattern
+to the last QUIC long header packet of a UDP datagram. When such a UDP datagram
+is received by an endpoint that does not understand TRONE, the TRONE Indication
+Pattern would be ignored while the long header packets will be processed
+({{Section 12.2 of QUIC}}).
+
+Other versions of QUIC might not support TRONE, or require different measures to
+set the last 16 bytes to the TRONE Indication Pattern.
+
+When sending QUIC short header packets in the first flight, endpoints SHOULD
+send them after the first datagram carrying the TRONE indication, as the TRONE
+Indication Pattern can be attached only to QUIC long header packets.
 
 QUIC endpoints MUST NOT rely on TRONE indications for correct operation of the
 QUIC protocol or the TRONE protocol. The indication is purely advisory for
@@ -372,45 +350,37 @@ network elements.
 
 ## Processing TRONE Indications
 
-Network elements can detect TRONE indication packets using a reverse parsing
-approach, without requiring full parsing of the Initial packet:
+Network elements can detect TRONE indication packets by using the following
+steps:
 
-1. Identify a UDP datagram containing a QUIC version 1 or 2 packet.
-2. Check if the datagram length exceeds the minimum expected size of a QUIC
-   Initial packet
-3. Examine the last byte of the datagram to see if it has the Header Form bit
-   set to 1
-4. If set, read backward to verify the Version field matches 0xTRONE1 or
-   0xTRONE2
-5. Optionally read the Connection ID fields and match them to the QUIC packet.
+1. Identify a UDP datagram containing a QUIC long header packet as defined in
+   {{INVARIANTS}}, and that the size of Version-Specific Data is no less than
+   16 bytes.
+2. Examine the last 16 byte of the datagram to see if it has the TRONE
+   Indication Bit Pattern.
 
 The following pseudocode shows how a network element might detect a TRONE
 indication:
 
 ~~~ pseudocode
-is_quic = is_quic_datagram(datagram)
-if is_quic and datagram_length > MIN_INITIAL_SIZE:
-  last_byte = datagram[datagram_length - 1]
-
-  if (last_byte & 0x80) == 0x80:
-    version_start = datagram_length - 8
-    version_end = datagram_length - 4
-    potential_version = datagram[version_start:version_end]
-
-    if potential_version == TRONE1_VERSION or potential_version == TRONE2_VERSION:
+is_long_header_quic = is_quic_long_header_packet(datagram)
+if is_long_header_quic
+  version_specific_data = get_quic_version_specific_data(datagram)
+  if length(version_specific_data) >= 16
+    potential_bit_pattern = datagram[length(datagram) - 16,length(datagram)]
+    if potential_bit_pattern == TRONE_INDICATION_BIT_PATTERN
       note_potential_trone_support(flow_tuple)
 ~~~
 
 This approach allows network elements to detect TRONE support without needing
-to parse the full QUIC Initial packet structure or perform deep packet
+to parse the version-specific QUIC packet structure or perform deep packet
 inspection of the TLS handshake.
 
-Network elements that observe TRONE indication packets MAY:
-* Note the UDP 4-tuple for potential future TRONE handling
-* NOT modify the TRONE indication packet (keep Rate Signal at 0x3F)
+Network elements that observe TRONE indication packets MAY note the UDP 4-tuple
+for potential future TRONE handling.
 
 Network elements MUST NOT rely solely on the presence of a TRONE indication to
-confirm that a flow supports TRONE. A flow should only be confirmed as
+confirm that a flow supports TRONE. A flow SHOULD only be confirmed as
 supporting TRONE when a regular TRONE packet ({{packet}}) is observed after the
 QUIC handshake has completed.
 

--- a/draft-thoji-scone-trone-protocol.md
+++ b/draft-thoji-scone-trone-protocol.md
@@ -380,7 +380,7 @@ Network elements that observe TRONE indication packets MAY note the UDP 4-tuple
 for potential future TRONE handling.
 
 Network elements MUST NOT rely solely on the presence of a TRONE indication to
-confirm that a flow supports TRONE. A flow SHOULD only be confirmed as
+confirm that a flow supports TRONE. A flow is only confirmed as
 supporting TRONE when a regular TRONE packet ({{packet}}) is observed after the
 QUIC handshake has completed.
 

--- a/draft-thoji-scone-trone-protocol.md
+++ b/draft-thoji-scone-trone-protocol.md
@@ -331,8 +331,8 @@ first UDP datagram it sends to the TRONE Indication Pattern. This is an
 opportunistic signal that is not guaranteed to be processed by the receiver, as
 the receiver has not yet confirmed its willingness to send TRONE packets.
 
-In the case of QUIC v1, endpoints can simply append the TRONE Indication Pattern
-to the last QUIC long header packet of a UDP datagram. When such a UDP datagram
+In the case of QUIC v1, endpoints can simply append the TRONE Indication Pattern (TIP)
+after the last QUIC long header packet of a UDP datagram. When such a UDP datagram
 is received by an endpoint that does not understand TRONE, the TRONE Indication
 Pattern would be ignored while the long header packets will be processed
 ({{Section 12.2 of QUIC}}).


### PR DESCRIPTION
This PR is against https://github.com/ietf-wg-scone/trone/pull/23.

The changes are:
* redefine the indication as a bit pattern at the end of a QUIC long header packet
* network elements check if the datagram is a QUIC long header packet (by looking at the first few bytes of the datagram), then check if last 16-bytes have a specific pattern
* point out that QUIC v1 endpoints can advertise TRONE support simply by appending the pattern, but other versions of QUIC might not be compatible with TRONE or might have different requirements

Note that as we refer to Invariants, there is no coalescing... a QUIC packet is always an entire datagram.

